### PR TITLE
GroupSharedExpenses migrations

### DIFF
--- a/database/migrations/2017_03_24_021429_CreateGroupSharedExpensesTable.php
+++ b/database/migrations/2017_03_24_021429_CreateGroupSharedExpensesTable.php
@@ -20,7 +20,7 @@ class CreateGroupSharedExpensesTable extends Migration
             $table->float('amount_owed');
             $table->string('comments');
             $table->date('date_added');
-            $table->date('date_settled'):
+            $table->date('date_settled');
         });
     }
 


### PR DESCRIPTION
has a : not a ;

we done goofed.